### PR TITLE
Fix default config path

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -42,9 +42,9 @@ func initConfig() {
 		// Use config file from the flag.
 		viper.SetConfigFile(cfgFile)
 	} else {
-		// Search config in home directory with name ".lostromos" (without extension).
+		// Use default config file /etc/lostromos.yaml
 		viper.AddConfigPath("/etc")
-		viper.SetConfigName("lostromos")
+		viper.SetConfigName("lostromos.yaml")
 	}
 
 	viper.AutomaticEnv() // read in environment variables that match


### PR DESCRIPTION
Our help text said the default config file was /etc/lostromos.yaml however we
were attempting to read /etc/lostromos. This commit fixes that.