### PR TITLE
Add Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,45 @@
+# My Issue
+
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Expected Behavior
+
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+## Current Behavior
+
+<!--- If describing a bug, tell us what happens instead of the expected -->
+<!--- behavior -->
+<!--- If suggesting a change/improvement, explain the difference from -->
+<!--- current behavior -->
+
+## Possible Solution
+
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas how to implement the addition or change -->
+
+## Steps to Reproduce (for bugs)
+
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+
+1.
+2.
+3.
+4.
+
+## Context
+
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful -->
+<!--- in the real world -->
+
+## Your Environment
+
+<!--- Include as many relevant details about the environment you experienced the
+      bug in -->
+* Version used:
+* Environment name and version (e.g. Golang 1.9 on K8s 1.7):
+* Server type and version:
+* Link to your project:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,7 +2,10 @@
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making
+participation in our project and our community a harassment-free experience for everyone, regardless of age, body size,
+disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
 
 ## Our Standards
 
@@ -24,23 +27,34 @@ Examples of unacceptable behavior by participants include:
 
 ## Our Responsibilities
 
-Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take
+appropriate and fair corrective action in response to any instances of unacceptable behavior.
 
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits,
+issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any
+contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the
+project or its community. Examples of representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed representative at an online or offline
+event. Representation of a project may be further defined and clarified by project maintainers.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at nicole@wpengine.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at
+nicole@wpengine.com. The project team will review and investigate all complaints, and will respond in a way that it
+deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the
+reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
-Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent
+repercussions as determined by other members of the project's leadership.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at
+[http://contributor-covenant.org/version/1/4][version].
 
 [homepage]: http://contributor-covenant.org
 [version]: http://contributor-covenant.org/version/1/4/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/wpengine/lostromos.svg?branch=master)](https://travis-ci.org/wpengine/lostromos)
 [![codecov](https://codecov.io/gh/wpengine/lostromos/branch/master/graph/badge.svg)](https://codecov.io/gh/wpengine/lostromos)
 
-**Under active development. Not ready for production usage.**
+**NOTE**: Under active development. Not ready for production usage.
 
 Lostromos is a service that creates Kubernetes resources based on a Custom Resource
 endpoint in the Kubernetes API. It is an implementation of the [Operator
@@ -24,5 +24,13 @@ docker image in deployments, a common annotation or label).
 
 ## Getting Started
 
-- [Continuous Integration](./docs/travisCI.md)
 - [Development](./docs/development.md)
+- [Continuous Integration](./docs/continuousIntegration.md)
+
+## Contributing
+
+See [Contributing](./CONTRIBUTING.md) to get started.
+
+## Report a Bug
+
+To report an issue or suggest an improvement please open an [issue](https://github.com/wpengine/lostromos/issues).

--- a/docs/continuousIntegration.md
+++ b/docs/continuousIntegration.md
@@ -1,4 +1,6 @@
-# Working with Travis CI
+# Continuous Integration
+
+## Working with Travis CI
 
 We use Travis as our continuous integration environment. In order to have a PR available for merging, it must pass the
 tests run as part of the CI pipeline. The same thing applies for a new build, which must pass testing against the master


### PR DESCRIPTION
Signed-off-by: Derek Rushing <derek.rushing21@gmail.com>

# What Are We Doing Here

1. Adding an issue template.
2. Renaming the travisCI.md file to continuousIntegration.md for more clarity.
3. Fixing some linting errors in the markdown related to line length and using emphasis instead of a header when saying Lostromos is under development.

## How to Verify

Documentation only change, so sign off on the docs is the only thing needed.