### PR TITLE
Fix travis lint failure non-breakage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ golint: | vendor
 	@gometalinter --enable=gofmt --vendor -D gotype
 
 lint-markdown:
-	@find . -path ./vendor -prune -o -name "*.md" -exec docker run --rm -v `pwd`/{}:/workspace/{} ${MARKDOWN_LINTER} /workspace/{} \;
+	@find . -path ./vendor -prune -o -name "*.md" -exec bash -c 'docker run --rm -v `pwd`/{}:/workspace/{} ${MARKDOWN_LINTER} /workspace/{} || kill $$PPID' \;
 
 install-deps:
 	go get -u github.com/golang/dep/cmd/dep


### PR DESCRIPTION
Signed-off-by: Derek Rushing <derek.rushing21@gmail.com>

# What Are We Doing Here

Fixing markdown linting to fail the build. Previously it was not because 'find' was eating all of the error outputs.

## How to Verify

1. Check out this PR and modify a markdown with "foo" at the top of the file. Run `make lint-markdown` and see that this change now fails the make target.