### PR TITLE
Adding template controller

### DIFF
--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -24,16 +24,11 @@ import (
 	restclient "k8s.io/client-go/rest"
 )
 
-func TestGetKubeClientForK8sPanicsWhenNotInCluster(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("The code did not panic")
-		}
-	}()
-
-	viper.Set("k8s.in-cluster", true)
+func TestGetKubeClientDefaultsToConfigFileWhenNotInCluster(t *testing.T) {
+	viper.Set("k8s.config", path.Join("..", "test-data", "kubeconfig"))
 	cfg := getKubeClient()
-	assert.Nil(t, cfg)
+	assert.NotNil(t, cfg)
+	assert.Equal(t, "https://localhost:8443", cfg.Host)
 }
 
 func TestGetKubeClientForKubeConfigFailsWhenFileNotFound(t *testing.T) {
@@ -43,14 +38,12 @@ func TestGetKubeClientForKubeConfigFailsWhenFileNotFound(t *testing.T) {
 		}
 	}()
 
-	viper.Set("k8s.in-cluster", false)
 	viper.Set("k8s.config", "/i-dont-exist/kubeconf")
 	cfg := getKubeClient()
 	assert.Nil(t, cfg)
 }
 
 func TestGetKubeClientForKubeConfigReturnsWhenFileExists(t *testing.T) {
-	viper.Set("k8s.in-cluster", false)
 	viper.Set("k8s.config", path.Join("..", "test-data", "kubeconfig"))
 	cfg := getKubeClient()
 	assert.NotNil(t, cfg)

--- a/docs/manual_testing.md
+++ b/docs/manual_testing.md
@@ -6,7 +6,7 @@ working as expected you can go through the following steps.
 1. Setup kubectl against a cluster (minikube works just fine)
 2. `kubectl apply -f test-data/crd.yml`
 3. `kubectl apply -f test-data/cr_things.yml`
-4. `go run main.go start --crd-group stable.nicolerenee.io --crd-name characters`
+4. `go run main.go start --config test-data/config.yaml`
     - See that it prints out that `thing1` and `thing2` were added
 5. In another shell `kubectl apply -f test-data/cr_nemo.yml`
     - See that it prints out that `nemo` was added

--- a/test-data/config.yaml
+++ b/test-data/config.yaml
@@ -1,0 +1,4 @@
+crd:
+  group: stable.nicolerenee.io
+  name: characters
+templates: ./test-data/templates

--- a/test-data/templates/0_base.tmpl
+++ b/test-data/templates/0_base.tmpl
@@ -1,0 +1,7 @@
+---
+
+{{ template "configmap.yaml.tmpl" .}}
+
+---
+
+{{ template "deployment.yaml.tmpl" .}}

--- a/test-data/templates/configmap.yaml.tmpl
+++ b/test-data/templates/configmap.yaml.tmpl
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .GetField "metadata" "name"  }}-configmap
+data:
+  by: {{ .GetField "spec" "By"  }}

--- a/test-data/templates/deployment.yaml.tmpl
+++ b/test-data/templates/deployment.yaml.tmpl
@@ -1,0 +1,17 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: {{ .GetField "metadata" "name"  }}-nginx
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ .GetField "metadata" "name"  }}
+        component: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:alpine
+        ports:
+        - containerPort: 80

--- a/tmplctlr/controller.go
+++ b/tmplctlr/controller.go
@@ -1,0 +1,117 @@
+// Copyright 2017 the lostromos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tmplctlr
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"path/filepath"
+	"text/template"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// Controller implements a valid crwatcher.ResourceController that will manage
+// resources in kubernetes based on the provided template files.
+type Controller struct {
+	templatePath string     //path to dir where templates are located
+	Client       KubeClient //client for talking with kubernetes
+}
+
+// NewController will return a configured Controller
+func NewController(tmplDir string, kubeCfg string) *Controller {
+	c := &Controller{
+		Client:       &Kubectl{ConfigFile: kubeCfg},
+		templatePath: filepath.Join(tmplDir, "*.tmpl"),
+	}
+	return c
+}
+
+// ResourceAdded is called when a custom resource is created and will generate
+// the template files and apply them to Kubernetes
+func (c Controller) ResourceAdded(r *unstructured.Unstructured) {
+	fmt.Printf("INFO: resource added, cr: %s\n", r.GetName())
+	c.apply(r)
+}
+
+// ResourceUpdated is called when a custom resource is updated or during a
+// resync and will generate the template files and apply them to Kubernetes
+func (c Controller) ResourceUpdated(oldR, newR *unstructured.Unstructured) {
+	fmt.Printf("INFO: resource updated, cr: %s\n", newR.GetName())
+	c.apply(newR)
+}
+
+func (c Controller) apply(r *unstructured.Unstructured) {
+	cr := &CustomResource{
+		Resource: r,
+	}
+	tmpFile, err := c.generateTemplate(cr)
+	if err != nil {
+		fmt.Printf("ERROR: failed to generate template error: %s\n", err)
+		return
+	}
+	out, err := c.Client.Apply(tmpFile)
+	if err != nil {
+		fmt.Printf("ERROR: failed to apply template error: %s\n", err)
+		return
+	}
+	fmt.Printf("DEBUG: applied Kubernetes objects, cr: %s results: %s\n", r.GetName(), out)
+}
+
+// ResourceDeleted is called when a custom resource is created and will generate
+// the template files and delete them from Kubernetes
+func (c Controller) ResourceDeleted(r *unstructured.Unstructured) {
+	cr := &CustomResource{
+		Resource: r,
+	}
+	fmt.Printf("INFO: resource deleted, cr: %s\n", r.GetName())
+	tmpFile, err := c.generateTemplate(cr)
+	if err != nil {
+		fmt.Printf("ERROR: failed to generate template error: %s\n", err)
+		return
+	}
+	out, err := c.Client.Delete(tmpFile)
+	if err != nil {
+		fmt.Printf("ERROR: failed to delete template error: %s\n", err)
+		return
+	}
+	fmt.Printf("DEBUG: deleted Kubernetes objects, cr: %s results: %s\n", r.GetName(), out)
+}
+
+func (c Controller) generateTemplate(cr *CustomResource) (string, error) {
+	tmpl, err := template.ParseGlob(c.templatePath)
+	if err != nil {
+		return "", err
+	}
+	tf, err := ioutil.TempFile("", "lostromos")
+	if err != nil {
+		return "", err
+	}
+	defer close(tf)
+	err = tmpl.Execute(tf, cr)
+	if err != nil {
+		return "", err
+	}
+	return tf.Name(), nil
+}
+
+func close(c io.Closer) {
+	err := c.Close()
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/tmplctlr/controller_test.go
+++ b/tmplctlr/controller_test.go
@@ -1,0 +1,122 @@
+// Copyright 2017 the lostromos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tmplctlr
+
+import (
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var (
+	basicResource = &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name": "dory",
+			},
+			"spec": map[string]interface{}{
+				"Name": "Dory",
+				"From": "Finding Nemo",
+				"By":   "Disney",
+			},
+		},
+	}
+
+	basicCR = &CustomResource{Resource: basicResource}
+
+	templates = []templateFile{
+		// T0.tmpl is a plain template file that just invokes T1.
+		{"0_base.tmpl", `--- {{template "file1.tmpl" . }}`},
+		// T1.tmpl defines a template, T1 that invokes T2.
+		{"file1.tmpl", `name: {{ .GetField "metadata" "name"  }}-configmap`},
+	}
+)
+
+// templateFile defines the contents of a template to be stored in a file, for testing.
+type templateFile struct {
+	name     string
+	contents string
+}
+
+func createTestDir(files []templateFile) string {
+	dir, err := ioutil.TempDir("", "template")
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, file := range files {
+		f, err := os.Create(filepath.Join(dir, file.name))
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer f.Close()
+		_, err = io.WriteString(f, file.contents)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func ExampleController_ResourceAdded() {
+	dir := createTestDir(templates)
+	// Clean up after the test; another quirk of running as an example.
+	defer os.RemoveAll(dir)
+
+	c := &Controller{
+		Client:       kubePrint{},
+		templatePath: filepath.Join(dir, "*.tmpl"),
+	}
+
+	c.ResourceAdded(basicResource)
+	// Output:
+	// INFO: resource added, cr: dory
+	// DEBUG: applied Kubernetes objects, cr: dory results: Kube Apply Called
+}
+
+func ExampleController_ResourceUpdated() {
+	dir := createTestDir(templates)
+	// Clean up after the test; another quirk of running as an example.
+	defer os.RemoveAll(dir)
+
+	c := &Controller{
+		Client:       kubePrint{},
+		templatePath: filepath.Join(dir, "*.tmpl"),
+	}
+
+	c.ResourceUpdated(basicResource, basicResource)
+	// Output:
+	// INFO: resource updated, cr: dory
+	// DEBUG: applied Kubernetes objects, cr: dory results: Kube Apply Called
+}
+
+func ExampleController_ResourceDeleted() {
+	dir := createTestDir(templates)
+	// Clean up after the test; another quirk of running as an example.
+	defer os.RemoveAll(dir)
+
+	c := &Controller{
+		Client:       kubePrint{},
+		templatePath: filepath.Join(dir, "*.tmpl"),
+	}
+
+	c.ResourceDeleted(basicResource)
+	// Output:
+	// INFO: resource deleted, cr: dory
+	// DEBUG: deleted Kubernetes objects, cr: dory results: Kube Delete Called
+}

--- a/tmplctlr/controllertmpl_test.go
+++ b/tmplctlr/controllertmpl_test.go
@@ -1,0 +1,62 @@
+// Copyright 2017 the lostromos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tmplctlr
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateTemplate(t *testing.T) {
+	// Here we create a temporary directory and populate it with our sample
+	// template definition files; usually the template files would already
+	// exist in some location known to the program.
+	dir := createTestDir([]templateFile{
+		// T0.tmpl is a plain template file that just invokes T1.
+		{"0_base.tmpl", `--- {{template "file1.tmpl" . }}`},
+		// T1.tmpl defines a template, T1 that invokes T2.
+		{"file1.tmpl", `name: {{ .GetField "metadata" "name"  }}-configmap`},
+	})
+	// Clean up after the test; another quirk of running as an example.
+	defer os.RemoveAll(dir)
+
+	c := NewController(dir, "")
+	tmpFile, err := c.generateTemplate(basicCR)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, tmpFile)
+
+	fmt.Printf("temp file: %s\n", tmpFile)
+
+	bytes, err := ioutil.ReadFile(tmpFile)
+	if err != nil {
+		log.Fatal("Failed to read file: " + tmpFile)
+	}
+
+	assert.Equal(t, "--- name: dory-configmap", string(bytes[:]))
+}
+
+func TestGenerateTemplateNoTemplatePath(t *testing.T) {
+	c := NewController("", "")
+	tmpFile, err := c.generateTemplate(basicCR)
+
+	assert.NotNil(t, err)
+	assert.Empty(t, tmpFile)
+}

--- a/tmplctlr/custom_resource.go
+++ b/tmplctlr/custom_resource.go
@@ -1,0 +1,49 @@
+// Copyright 2017 the lostromos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tmplctlr
+
+import "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+// CustomResource provides some helper methods for interacting with the
+// kubernetes custom resource inside the templates.
+type CustomResource struct {
+	Resource *unstructured.Unstructured // represents the resource from kubernetes
+}
+
+// Name will return the Name from the custom resource
+func (cr CustomResource) Name() string {
+	return cr.Resource.GetName()
+}
+
+// GetField will traverse all the fields to return the string value of the
+// requested field. If the field is not found it will return an empty string
+func (cr CustomResource) GetField(fields ...string) string {
+	if str, ok := getNestedField(cr.Resource.Object, fields...).(string); ok {
+		return str
+	}
+	return ""
+}
+
+// copied from https://github.com/kubernetes/apimachinery/blob/master/pkg/apis/meta/v1/unstructured/unstructured.go
+func getNestedField(obj map[string]interface{}, fields ...string) interface{} {
+	var val interface{} = obj
+	for _, field := range fields {
+		if _, ok := val.(map[string]interface{}); !ok {
+			return nil
+		}
+		val = val.(map[string]interface{})[field]
+	}
+	return val
+}

--- a/tmplctlr/custom_resource_test.go
+++ b/tmplctlr/custom_resource_test.go
@@ -1,0 +1,36 @@
+// Copyright 2017 the lostromos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tmplctlr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestName(t *testing.T) {
+	r := basicCR.Name()
+	assert.Equal(t, "dory", r)
+}
+
+func TestGetField(t *testing.T) {
+	r := basicCR.GetField("metadata", "name")
+	assert.Equal(t, "dory", r)
+}
+
+func TestGetFieldReturnsEmptyIfNotFound(t *testing.T) {
+	r := basicCR.GetField("Something", "made", "up")
+	assert.Empty(t, r)
+}

--- a/tmplctlr/kubeclient.go
+++ b/tmplctlr/kubeclient.go
@@ -1,0 +1,65 @@
+// Copyright 2017 the lostromos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tmplctlr
+
+import (
+	"os"
+	"os/exec"
+)
+
+// KubeClient is an interface that implements an Apply() and Delete() for our K8s templates
+type KubeClient interface {
+	Apply(file string) (string, error)
+	Delete(file string) (string, error)
+}
+
+// Kubectl provides a simple wrapper around calling the needed kubectl commands
+// TODO: This should be revisited when https://github.com/kubernetes/kubernetes/issues/15894 is completed.
+// #15894 will move the apply logic from kubectl into the API
+type Kubectl struct {
+	ConfigFile string //config file for kubectl
+}
+
+var execCommand = exec.Command
+
+// Apply will execute kubectl apply -f file with the correct config
+func (k Kubectl) Apply(file string) (string, error) {
+	if k.ConfigFile != "" {
+		err := os.Setenv("KUBECONFIG", k.ConfigFile)
+		if err != nil {
+			return "", err
+		}
+	}
+	out, err := execCommand("kubectl", "apply", "-f", file).CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	return string(out[:]), nil
+}
+
+// Delete will execute kubectl delete -f file with the correct config
+func (k Kubectl) Delete(file string) (string, error) {
+	if k.ConfigFile != "" {
+		err := os.Setenv("KUBECONFIG", k.ConfigFile)
+		if err != nil {
+			return "", err
+		}
+	}
+	out, err := execCommand("kubectl", "delete", "-f", file).CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	return string(out[:]), nil
+}

--- a/tmplctlr/kubeclient_test.go
+++ b/tmplctlr/kubeclient_test.go
@@ -1,0 +1,116 @@
+// Copyright 2017 the lostromos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tmplctlr
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type kubePrint struct {
+}
+
+func (k kubePrint) Apply(file string) (string, error) {
+	return "Kube Apply Called", nil
+}
+
+func (k kubePrint) Delete(file string) (string, error) {
+	return "Kube Delete Called", nil
+}
+
+func fakeExecCommand(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestHelperProcess", "--", command}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+	return cmd
+}
+
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	fmt.Print(os.Args[3:])
+	if os.Args[len(os.Args)-1] == "ERROR" {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+func TestKubectlApply(t *testing.T) {
+	execCommand = fakeExecCommand
+	defer func() { execCommand = exec.Command }()
+
+	k := &Kubectl{}
+	out, err := k.Apply("path")
+	assert.Nil(t, err)
+	assert.Equal(t, "[kubectl apply -f path]", out)
+}
+
+func TestKubectlApplyCmdError(t *testing.T) {
+	execCommand = fakeExecCommand
+	defer func() { execCommand = exec.Command }()
+
+	k := &Kubectl{}
+	out, err := k.Apply("ERROR")
+	assert.NotNil(t, err)
+	assert.Empty(t, out)
+}
+
+func TestKubectlApplyConfigFile(t *testing.T) {
+	execCommand = fakeExecCommand
+	defer func() { execCommand = exec.Command }()
+
+	k := &Kubectl{ConfigFile: "some_file"}
+	out, err := k.Apply("path")
+	assert.Nil(t, err)
+	assert.Equal(t, "some_file", os.Getenv("KUBECONFIG"))
+	assert.Equal(t, "[kubectl apply -f path]", out)
+}
+
+func TestKubectlDelete(t *testing.T) {
+	execCommand = fakeExecCommand
+	defer func() { execCommand = exec.Command }()
+
+	k := &Kubectl{}
+	out, err := k.Delete("path")
+	assert.Nil(t, err)
+	assert.Equal(t, "[kubectl delete -f path]", out)
+}
+
+func TestKubectlDeleteConfigFile(t *testing.T) {
+	execCommand = fakeExecCommand
+	defer func() { execCommand = exec.Command }()
+
+	k := &Kubectl{ConfigFile: "some_file"}
+	out, err := k.Delete("path")
+	assert.Nil(t, err)
+	assert.Equal(t, "some_file", os.Getenv("KUBECONFIG"))
+	assert.Equal(t, "[kubectl delete -f path]", out)
+}
+
+func TestKubectlDeleteCmdError(t *testing.T) {
+	execCommand = fakeExecCommand
+	defer func() { execCommand = exec.Command }()
+
+	k := &Kubectl{}
+	out, err := k.Delete("ERROR")
+	assert.NotNil(t, err)
+	assert.Empty(t, out)
+}


### PR DESCRIPTION
# What Are We Doing Here

Adding an initial version of a template controller that can parse templates and apply them to k8s.

## How to Verify

1. Follow the steps documented in manual_testing.md
2. After adding/updating/deleting a resource ensure the corresponding k8s configmap and deployment have been altered