### PR TITLE
Add prometheus metrics endpoint to start command.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,6 +14,12 @@
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  revision = "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9"
+
+[[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
@@ -87,6 +93,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/golang/protobuf"
+  packages = ["proto"]
+  revision = "1643683e1b54a9e88ad26d98f81400c8c9d9f4f9"
+
+[[projects]]
+  branch = "master"
   name = "github.com/google/gofuzz"
   packages = ["."]
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
@@ -140,6 +152,12 @@
   revision = "3fd5e860b68f3cc81671ece2e226c78a6bbf54d3"
 
 [[projects]]
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  revision = "3247c84500bff8d9fb6d579d800f20b3e091582c"
+  version = "v1.0.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
@@ -162,6 +180,30 @@
   packages = ["difflib"]
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/prometheus/client_golang"
+  packages = ["prometheus"]
+  revision = "c5b7fccd204277076155f10851dad72b76a49317"
+  version = "v0.8.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  revision = "6f3806018612930941127f2a7c6c453ba2c527d2"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/common"
+  packages = ["expfmt","internal/bitbucket.org/ww/goautoneg","model"]
+  revision = "1bab55dd05dbff384524a6a1c99006d9eb5f139b"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/procfs"
+  packages = [".","xfs"]
+  revision = "a6e9df898b1336106c743392c48ee0b71f5c4efa"
 
 [[projects]]
   branch = "master"
@@ -260,6 +302,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "95041363c4e5e6871e117489b554e77ac3e1c898c1cb261b7860e83fae63e455"
+  inputs-digest = "de8ad0d948cbee59f04f8ed2517b5823e54c3d4a1a9243c842df7471a9e024a7"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -22,3 +22,7 @@
 [[constraint]]
   name = "github.com/golang/mock"
   version = "v1.0.0"
+
+[[constraint]]
+  name = "github.com/prometheus/client_golang"
+  version = "0.8.0"

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -1,0 +1,42 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	// CreatedReleases is a metric for the number of releases created by this operator
+	CreatedReleases = prometheus.NewCounter(prometheus.CounterOpts{
+		Help:      "The number of create processed by this operator",
+		Name:      "created_count",
+		Namespace: "releases",
+	})
+
+	// DeletedReleases is a metric for the number of releases deleted by this operator
+	DeletedReleases = prometheus.NewCounter(prometheus.CounterOpts{
+		Help:      "The number of delete requests processed by this operator",
+		Name:      "deleted_count",
+		Namespace: "releases",
+	})
+
+	// ManagedReleases is a metric of the number of current releases managed by the operator
+	ManagedReleases = prometheus.NewGauge(prometheus.GaugeOpts{
+		Help:      "The number of releases managed by this operator",
+		Name:      "managed_total",
+		Namespace: "releases",
+	})
+
+	// UpdatedReleases is a metric for the number of releases updated by this operator
+	UpdatedReleases = prometheus.NewCounter(prometheus.CounterOpts{
+		Help:      "The number of updates processed by this operator",
+		Name:      "updated_count",
+		Namespace: "releases",
+	})
+)
+
+func init() {
+	prometheus.MustRegister(CreatedReleases)
+	prometheus.MustRegister(DeletedReleases)
+	prometheus.MustRegister(ManagedReleases)
+	prometheus.MustRegister(UpdatedReleases)
+}

--- a/tmplctlr/controller.go
+++ b/tmplctlr/controller.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"text/template"
 
+	"github.com/wpengine/lostromos/metrics"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -46,6 +47,8 @@ func NewController(tmplDir string, kubeCfg string) *Controller {
 func (c Controller) ResourceAdded(r *unstructured.Unstructured) {
 	fmt.Printf("INFO: resource added, cr: %s\n", r.GetName())
 	c.apply(r)
+	metrics.CreatedReleases.Inc()
+	metrics.ManagedReleases.Inc()
 }
 
 // ResourceUpdated is called when a custom resource is updated or during a
@@ -53,6 +56,7 @@ func (c Controller) ResourceAdded(r *unstructured.Unstructured) {
 func (c Controller) ResourceUpdated(oldR, newR *unstructured.Unstructured) {
 	fmt.Printf("INFO: resource updated, cr: %s\n", newR.GetName())
 	c.apply(newR)
+	metrics.UpdatedReleases.Inc()
 }
 
 func (c Controller) apply(r *unstructured.Unstructured) {
@@ -92,6 +96,8 @@ func (c Controller) ResourceDeleted(r *unstructured.Unstructured) {
 		return
 	}
 	fmt.Printf("DEBUG: deleted Kubernetes objects, cr: %s results: %s\n", r.GetName(), out)
+	metrics.DeletedReleases.Inc()
+	metrics.ManagedReleases.Dec()
 }
 
 func (c Controller) generateTemplate(cr *CustomResource) (string, error) {


### PR DESCRIPTION
Signed-off-by: Josh Yelton <josh.yelton@wpengine.com>

# What Are We Doing Here

Adding a /metrics endpoint that outputs metrics in the prometheus format.

## How to Verify

1. Check out this PR
2. Setup kubectl against a cluster (minikube works just fine)
3. kubectl apply -f test-data/crd.yml
4. kubectl apply -f test-data/cr_things.yml
5. go run main.go --config test-data/config.yaml start
6. curl localhost:8080/metrics
- Verify you see output in the prometheus format