### PR TITLE
Enable fast finish for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   - INTEGRATION=false
 
 matrix:
+  fast_finish: true
   allow_failures:
   - go: master
 


### PR DESCRIPTION
# What Are We Doing Here

This will configure travis to report the build as passed to Github as soon as the required test suites pass.
