### PR TITLE
Setting the default Helm namespace

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -54,7 +54,7 @@ func init() {
 	startCmd.Flags().String("crd-version", "v1", "the version of the CRD you want monitored")
 	startCmd.Flags().String("crd-namespace", metav1.NamespaceNone, "(optional) the namespace of the CRD you want monitored, only needed for namespaced CRDs (ex: default)")
 	startCmd.Flags().String("helm-chart", "", "Path for helm chart")
-	startCmd.Flags().String("helm-ns", "", "Namespace for resources deployed by helm")
+	startCmd.Flags().String("helm-ns", "default", "Namespace for resources deployed by helm")
 	startCmd.Flags().String("helm-prefix", "lostromos", "Prefix for release names in helm")
 	startCmd.Flags().String("helm-tiller", "tiller-deploy:44134", "Address for helm tiller")
 	startCmd.Flags().String("kube-config", filepath.Join(homeDir(), ".kube", "config"), "absolute path to the kubeconfig file. Only required if running outside-of-cluster.")

--- a/helmctlr/helm.go
+++ b/helmctlr/helm.go
@@ -24,12 +24,14 @@ import (
 	"k8s.io/helm/pkg/helm"
 )
 
+var defaultNS = "default"
+
 // Controller is a crwatcher.ResourceController that works with Helm to deploy
 // helm charts into K8s providing a CustomResource as value data to the charts
 type Controller struct {
 	ChartDir    string         // path to dir where the Helm chart is located
 	Helm        helm.Interface // Helm for talking with helm
-	Namespace   string         // Default namespace to deploy into. If empty it will try to use the namespace from the CustomResource
+	Namespace   string         // Default namespace to deploy into. If empty it will default to "default"
 	ReleaseName string         // Prefix for the helm release name. Will look like ReleaseName-CR_Name
 	logger      *zap.SugaredLogger
 }
@@ -39,6 +41,9 @@ func NewController(chartDir, ns, rn, host string, logger *zap.SugaredLogger) *Co
 	if logger == nil {
 		// If you don't give us a logger, set logger to a nop logger
 		logger = zap.NewNop().Sugar()
+	}
+	if ns == "" {
+		ns = defaultNS
 	}
 	c := &Controller{
 		Helm:        helm.NewClient(helm.Host(host)),

--- a/helmctlr/helm_test.go
+++ b/helmctlr/helm_test.go
@@ -109,6 +109,16 @@ func assertCounters(t *testing.T, c counterTest, f func()) {
 	assert.Equal(t, float64(c.releases), ra-rb, "change in releases_total incorrect")
 }
 
+func TestNewControllerSetsNS(t *testing.T) {
+	c := helmctlr.NewController("chartDir", "", "release", "127.0.0.3:4321", nil)
+	assert.Equal(t, "default", c.Namespace, "Namespace should be set to 'default' when not provided")
+	assert.Equal(t, "chartDir", c.ChartDir)
+	assert.Equal(t, "release", c.ReleaseName)
+
+	c = helmctlr.NewController("chartDir", "my_ns", "release", "127.0.0.3:4321", nil)
+	assert.Equal(t, "my_ns", c.Namespace, "Namespace should be set to the value provided")
+}
+
 func TestResourceAddedHappyPath(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()


### PR DESCRIPTION
# What Are We Doing Here

When you don't provide a namespace for helm we should default it to something. So using the default k8s namespace of "default"