### PR TITLE
Dep lockfile out of sync

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -385,6 +385,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2ee517a4cfa0a5a7828ec3932cfe88a8da7bdee2e4e30c5c26c4e24121b5395a"
+  inputs-digest = "fb0558df8060fd290a7e5ef8c4d8ce229fd29230be237e128f85cc0f53776db7"
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
The lock file got out of sync. Updating it.

We should likely add something to the CI pipeline that causes this to fail if we are out of sync.