### PR TITLE
Run install-deps as part of make all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+.PHONY: test
+
 APP           := lostromos
 PKG           := github.com/wpengine/lostromos
 
@@ -28,7 +30,7 @@ OWNER=wpengine
 IMAGE_NAME=lostromos
 QNAME=$(OWNER)/$(IMAGE_NAME)
 
-all: lint test build
+all: install-deps lint test build
 
 build:
 	@echo Building...
@@ -40,7 +42,6 @@ out/lostromos-%-amd64:
 	@echo Building for $*...
 	@GOOS=$* CGO_ENABLED=0 go build -ldflags "$(LD_FLAGS)" -o $@ main.go
 
-.PHONY: test
 test: | vendor
 	@echo Testing...
 	@go test ./... -cover


### PR DESCRIPTION
Signed-off-by: Derek Rushing <derek.rushing21@gmail.com>

# What Are We Doing Here

Moving around the makefile to ensure that running `make` does everything necessary to perform a successful build. Previously new-comers to the project might not have the proper dependencies, and therefore the `make` call would fail.

## How to Verify

1. Check out this PR and run `make` and see that everything works.