### PR TITLE
Fix missing kubectl command in quickstart.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ minikube start
 eval $(minikube docker-env) # This links docker with minikube so that the image you build in the next step will be available.
 make docker-build-test
 kubectl create -f test/data/crd.yml
+kubectl expose pod lostromos --type=LoadBalancer
 make LOSTROMOS_IP_AND_PORT=`minikube service lostromos --url | cut -c 8-` integration-tests
 eval $(minikube docker-env -u) # Unlinks minikube and docker.
 ```


### PR DESCRIPTION
Signed-off-by: Derek Rushing <derek.rushing21@gmail.com>

# What Are We Doing Here

Adding missing step to quickstart script.

## How to Verify

1. Check out this PR and run the quickstart script.