### PR TITLE
Adding wait and timeout options to helm controller

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
   - CHANGE_MINIKUBE_NONE_USER=true
   - KUBERNETES_VERSION=v1.8.0
   - MINIKUBE_VERSION=v0.23.0
+  - HELM_VERSION=v2.7.2
 go:
 - 1.9.x
 - master
@@ -21,8 +22,10 @@ before_install:
 - sudo make install-python-deps
 - make pull-linters
 install:
+- "./test/scripts/nsenter.sh"
 # Installing Minikube. Taken from https://kinvolk.io/blog/2017/10/running-kubernetes-on-travis-ci-with-minikube/
 - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+- curl -LO https://storage.googleapis.com/kubernetes-helm/helm-$HELM_VERSION-linux-amd64.tar.gz && tar -xzf helm-$HELM_VERSION-linux-amd64.tar.gz && sudo mv linux-amd64/helm /usr/local/bin/ && rm -rf linux-amd64
 - curl -Lo minikube https://storage.googleapis.com/minikube/releases/$MINIKUBE_VERSION/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
 - sudo minikube start --vm-driver=none --kubernetes-version=$KUBERNETES_VERSION
 - minikube update-context
@@ -33,7 +36,7 @@ install:
 script:
 - make lint
 - make test
-- make build-cross
+- make -j 3 build-cross
 - make docker-build-test
 - make LOSTROMOS_IP_AND_PORT=`minikube service lostromos --url | cut -c 8-` integration-tests
 - kubectl logs lostromos

--- a/status/status.go
+++ b/status/status.go
@@ -29,7 +29,10 @@ type Response struct {
 // Handler is used for managing calls to /status to inform of the current status of Lostromos.
 func Handler(writer http.ResponseWriter, request *http.Request) {
 	writer.Header().Set("Content-Type", "application/json")
-	fmt.Fprint(writer, jsonResponse())
+	_, err := fmt.Fprint(writer, jsonResponse())
+	if err != nil {
+		panic(err)
+	}
 }
 
 // Create a Json Response to return as the status.
@@ -38,6 +41,9 @@ func jsonResponse() string {
 		Success: true,
 		Info:    "Up and Running!",
 	}
-	bytes, _ := json.Marshal(response)
+	bytes, err := json.Marshal(response)
+	if err != nil {
+		panic(err)
+	}
 	return string(bytes)
 }

--- a/test/data/helm/brokenchart/Chart.yaml
+++ b/test/data/helm/brokenchart/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for testing lostromos
+name: helloworld
+version: 0.1.0

--- a/test/data/helm/brokenchart/templates/_helpers.tpl
+++ b/test/data/helm/brokenchart/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/test/data/helm/brokenchart/templates/deployment.yaml
+++ b/test/data/helm/brokenchart/templates/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ .Values.resource.name }}-hello
+  labels:
+    app: {{ .Values.resource.name }}-hello
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicas }}
+  template:
+    metadata:
+      labels:
+        resource: {{ .Values.resource.name }}
+        component: hello
+        By: {{ .Values.resource.spec.By | replace " " "_" }}
+    spec:
+      containers:
+      - name: hello
+        image: {{ .Values.image }}
+        resources:
+          requests:
+            cpu: "10m"
+          limits:
+            cpu: "100m"
+        ports:
+        - containerPort: 80

--- a/test/data/helm/brokenchart/values.yaml
+++ b/test/data/helm/brokenchart/values.yaml
@@ -1,0 +1,6 @@
+image: dockercloud/hello-world:abrokentag
+replicas: 3
+resource:
+  name: hercules
+  spec:
+    by: greece

--- a/test/data/helm/wait-config.yaml
+++ b/test/data/helm/wait-config.yaml
@@ -1,0 +1,13 @@
+crd:
+  group: stable.nicolerenee.io
+  name: characters
+helm:
+  chart: test/data/helm/brokenchart
+  namespace: lostromos
+  tiller: 192.168.99.100:32664
+  wait: true
+  waitTimeout: 10
+
+logging:
+  debug: true
+  pretty: true

--- a/test/data/tiller_nodeport_service.yml
+++ b/test/data/tiller_nodeport_service.yml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: tiller-deploy-nodeport
+  name: tiller-deploy-nodeport
+  namespace: kube-system
+spec:
+  ports:
+  - name: tiller
+    nodePort: 32664
+    protocol: TCP
+    port: 32665
+    targetPort: 44134
+  selector:
+    app: helm
+    name: tiller
+  type: NodePort

--- a/test/scripts/nsenter.sh
+++ b/test/scripts/nsenter.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+NSENTER_IMAGE=jpetazzo/nsenter
+
+check_or_build_nsenter() {
+    which nsenter >/dev/null && return 0
+    echo "INFO: Building 'nsenter' ..."
+    docker pull $NSENTER_IMAGE
+    docker run --rm -v `pwd`:/target $NSENTER_IMAGE
+    if [ ! -f ./nsenter ]; then
+        echo "ERROR: nsenter pull failed, log:"
+        return 1
+    fi
+    echo "INFO: nsenter build OK, installing ..."
+    install_bin ./nsenter
+}
+
+install_bin() {
+    local exe=${1:?}
+    test -n "${TRAVIS}" && sudo install -v ${exe} /usr/local/bin || install ${exe} ${GOPATH:?}/bin
+}
+
+check_or_build_nsenter


### PR DESCRIPTION
Signed-off-by: Josh Yelton <josh.yelton@wpengine.com>

# What Are We Doing Here

Adding the ability to add the Wait and Timeout options to the helm controller for installs and upgrades.  This allows the operator to conditionally wait for releases to successfully create resources before being marked as DEPLOYED.

## How to Verify

I've added steps to the integration tests to deploy a tiller into the minikube instance and wait for a broken release to timeout and be marked as FAILED.