### PR TITLE
Lostromos should have an opt in mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ eval $(minikube docker-env -u) # Unlinks minikube and docker.
 - [Continuous Integration](./docs/continuousIntegration.md)
   - [Testing](./docs/testing.md)
 - [Deployment](./docs/deployment.md)
+- [Understanding Lostromos Events](./docs/events.md)
 
 ## Contributing
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -54,6 +54,7 @@ func init() {
 	startCmd.Flags().String("crd-group", "", "the group of the CRD you want monitored (ex: stable.wpengine.io)")
 	startCmd.Flags().String("crd-version", "v1", "the version of the CRD you want monitored")
 	startCmd.Flags().String("crd-namespace", metav1.NamespaceNone, "(optional) the namespace of the CRD you want monitored, only needed for namespaced CRDs (ex: default)")
+	startCmd.Flags().String("crd-filter", "", "(optional) Annotation key to specify that the custom resource has opted in to watching by Lostromos")
 	startCmd.Flags().String("helm-chart", "", "Path for helm chart")
 	startCmd.Flags().String("helm-ns", "default", "Namespace for resources deployed by helm")
 	startCmd.Flags().String("helm-prefix", "lostromos", "Prefix for release names in helm")
@@ -71,6 +72,7 @@ func init() {
 	viperBindFlag("crd.group", startCmd.Flags().Lookup("crd-group"))
 	viperBindFlag("crd.version", startCmd.Flags().Lookup("crd-version"))
 	viperBindFlag("crd.namespace", startCmd.Flags().Lookup("crd-namespace"))
+	viperBindFlag("crd.filter", startCmd.Flags().Lookup("crd-filter"))
 	viperBindFlag("helm.chart", startCmd.Flags().Lookup("helm-chart"))
 	viperBindFlag("helm.namespace", startCmd.Flags().Lookup("helm-ns"))
 	viperBindFlag("helm.releasePrefix", startCmd.Flags().Lookup("helm-prefix"))
@@ -114,6 +116,7 @@ func buildCRWatcher(cfg *restclient.Config) (*crwatcher.CRWatcher, error) {
 		Group:      viper.GetString("crd.group"),
 		Version:    viper.GetString("crd.version"),
 		Namespace:  viper.GetString("crd.namespace"),
+		Filter:     viper.GetString("crd.filter"),
 	}
 	ctlr := getController()
 	l := &crLogger{logger: logger}

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -55,10 +55,12 @@ func TestBuildCRWatcherReturnsProperlyConfiguredWatcher(t *testing.T) {
 	crdName := "testCRD"
 	crdNamespace := "lostromos"
 	crdVersion := "v9876"
+	crdFilter := "useThisResource"
 	viper.Set("crd.group", crdGroup)
 	viper.Set("crd.name", crdName)
 	viper.Set("crd.namespace", crdNamespace)
 	viper.Set("crd.version", crdVersion)
+	viper.Set("crd.filter", crdFilter)
 
 	kubeCfg := &restclient.Config{}
 	crw, err := buildCRWatcher(kubeCfg)
@@ -68,6 +70,7 @@ func TestBuildCRWatcherReturnsProperlyConfiguredWatcher(t *testing.T) {
 	assert.Equal(t, crdName, crw.Config.PluralName)
 	assert.Equal(t, crdNamespace, crw.Config.Namespace)
 	assert.Equal(t, crdVersion, crw.Config.Version)
+	assert.Equal(t, crdFilter, crw.Config.Filter)
 }
 
 func TestGetControllerReturnsHelmController(t *testing.T) {

--- a/crwatcher/watcher_test.go
+++ b/crwatcher/watcher_test.go
@@ -84,7 +84,9 @@ func TestSetupHandlerAddFunc(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	mockRC := NewMockResourceController(mockCtrl)
-	cw := &CRWatcher{}
+	cw := &CRWatcher{
+		Config: &Config{},
+	}
 	r := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"metadata": map[string]interface{}{
@@ -99,12 +101,52 @@ func TestSetupHandlerAddFunc(t *testing.T) {
 	cw.handler.OnAdd(r)
 }
 
+// Test to ensure that if we are given filter criteria we only call ResourceAdded for a resource with the specified
+// filter.
+func TestSetupHandlerAddFuncUsesFilter(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockRC := NewMockResourceController(mockCtrl)
+	cw := &CRWatcher{
+		Config: &Config{
+			Filter: "com.wpengine.lostromos.filter",
+		},
+	}
+	r1 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name": "Thing1",
+			},
+		},
+	}
+	r2 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name": "Thing2",
+				"annotations": map[string]interface{}{
+					"com.wpengine.lostromos.filter": "true",
+				},
+			},
+		},
+	}
+	cw.setupHandler(mockRC)
+
+	mockRC.EXPECT().ResourceAdded(r1).MinTimes(0).MaxTimes(0)
+	mockRC.EXPECT().ResourceAdded(r2)
+
+	cw.handler.OnAdd(r1)
+	cw.handler.OnAdd(r2)
+}
+
 func TestSetupHandlerDeleteFunc(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
 	mockRC := NewMockResourceController(mockCtrl)
-	cw := &CRWatcher{}
+	cw := &CRWatcher{
+		Config: &Config{},
+	}
 	r := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"metadata": map[string]interface{}{
@@ -119,12 +161,52 @@ func TestSetupHandlerDeleteFunc(t *testing.T) {
 	cw.handler.OnDelete(r)
 }
 
+// Test to ensure that if we are given filter criteria we only call ResourceDeleted for a resource with the specified
+// filter.
+func TestSetupHandlerDeleteFuncUsesFilter(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockRC := NewMockResourceController(mockCtrl)
+	cw := &CRWatcher{
+		Config: &Config{
+			Filter: "com.wpengine.lostromos.filter",
+		},
+	}
+	r1 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name": "Thing1",
+			},
+		},
+	}
+	r2 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name": "Thing2",
+				"annotations": map[string]interface{}{
+					"com.wpengine.lostromos.filter": "true",
+				},
+			},
+		},
+	}
+	cw.setupHandler(mockRC)
+
+	mockRC.EXPECT().ResourceDeleted(r1).MinTimes(0).MaxTimes(0)
+	mockRC.EXPECT().ResourceDeleted(r2)
+
+	cw.handler.OnDelete(r1)
+	cw.handler.OnDelete(r2)
+}
+
 func TestSetupHandlerUpdateFunc(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
 	mockRC := NewMockResourceController(mockCtrl)
-	cw := &CRWatcher{}
+	cw := &CRWatcher{
+		Config: &Config{},
+	}
 	r1 := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"metadata": map[string]interface{}{
@@ -144,6 +226,65 @@ func TestSetupHandlerUpdateFunc(t *testing.T) {
 	mockRC.EXPECT().ResourceUpdated(r1, r2)
 
 	cw.handler.OnUpdate(r1, r2)
+}
+
+// Test to ensure that if we are given filter criteria we call ResourceUpdated, ResourceDeleted, and ResourceAdded
+// appropriately for filtered and unfiltered resources.
+func TestSetupHandlerUpdateFuncUsesFilter(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockRC := NewMockResourceController(mockCtrl)
+	cw := &CRWatcher{
+		Config: &Config{
+			Filter: "com.wpengine.lostromos.filter",
+		},
+	}
+	r1 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name": "Thing1",
+			},
+		},
+	}
+	r1Filtered := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name": "Thing1",
+				"annotations": map[string]interface{}{
+					"com.wpengine.lostromos.filter": "true",
+				},
+			},
+		},
+	}
+	r2 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name": "Thing2",
+			},
+		},
+	}
+	r2Filtered := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name": "Thing2",
+				"annotations": map[string]interface{}{
+					"com.wpengine.lostromos.filter": "true",
+				},
+			},
+		},
+	}
+	cw.setupHandler(mockRC)
+
+	mockRC.EXPECT().ResourceUpdated(r1, r2).MinTimes(0).MaxTimes(0)
+	mockRC.EXPECT().ResourceDeleted(r1Filtered)
+	mockRC.EXPECT().ResourceAdded(r2Filtered)
+	mockRC.EXPECT().ResourceUpdated(r1Filtered, r2Filtered)
+
+	cw.handler.OnUpdate(r1, r2)
+	cw.handler.OnUpdate(r1Filtered, r2)
+	cw.handler.OnUpdate(r1, r2Filtered)
+	cw.handler.OnUpdate(r1Filtered, r2Filtered)
 }
 
 func TestWatchReturnsErrorIfNotSetup(t *testing.T) {

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,16 @@
+# Understanding Lostromos Events
+
+This document is meant to describe the events that will occur when you use Lostromos with different settings.
+
+## Updates with a Filter
+
+When performing updates and using a non empty filter via the `crd.filter` option, we have defined the behavior:
+
+| Old Resource | New Resource | Action Taken |
+| ------------ | ------------ | ------------ |
+| Filter Annotation Exists | Filter Annotation Exists | ResourceUpdated |
+| Filter Annotation Doesn't Exist | Filter Annotation Exists | ResourceAdded |
+| Filter Annotation Exists | Filter Annotation Doesn't Exist | ResourceDeleted |
+| Filter Annotation Doesn't Exist | Filter Annotation Doesn't Exist | No-Op |
+
+In the case that filtering isn't used, `ResourceUpdated` is called.

--- a/docs/workingWithLostromos.md
+++ b/docs/workingWithLostromos.md
@@ -29,6 +29,8 @@ To start working with Lostrómos, you should begin by playing around with some b
   * `group` (Required) The group of the CRD you want monitored (ex: stable.wpengine.io)
   * `version` (Required) The version of the CRD you want monitored
   * `namespace` The namespace of the CRD you want monitored
+  * `filter` Filter to specify if Lostromos will act on a resource create/update/delete. For more detailed information
+             about what events happen on filtered updates check [here](./events.md)
 * `helm` Information pertaining to helm deployments. Defaults to use the go template controller if no information is
     given.
   * `chart` Path to helm chart

--- a/test/data/cr_things_filter.yml
+++ b/test/data/cr_things_filter.yml
@@ -4,6 +4,8 @@ apiVersion: stable.nicolerenee.io/v1
 kind: Character
 metadata:
   name: thing1
+  annotations:
+    io.nicolerenee.lostromosApplied: Opting In
 spec:
   Name: Thing 1
   From: Cat in the Hat
@@ -17,5 +19,18 @@ metadata:
   name: thing2
 spec:
   Name: Thing 2
+  From: Cat in the Hat
+  By: Dr. Seuss
+
+---
+
+apiVersion: stable.nicolerenee.io/v1
+kind: Character
+metadata:
+  name: thing3
+  annotations:
+    io.nicolerenee.lostromosApplied: Opting In Again
+spec:
+  Name: Thing 3
   From: Cat in the Hat
   By: Dr. Seuss

--- a/test/data/cr_things_filter_update.yml
+++ b/test/data/cr_things_filter_update.yml
@@ -15,7 +15,23 @@ apiVersion: stable.nicolerenee.io/v1
 kind: Character
 metadata:
   name: thing2
+  annotations:
+    io.nicolerenee.lostromosApplied: Opting In
 spec:
   Name: Thing 2
   From: Cat in the Hat
   By: Dr. Seuss
+
+---
+
+apiVersion: stable.nicolerenee.io/v1
+kind: Character
+metadata:
+  name: thing3
+  annotations:
+    io.nicolerenee.lostromosApplied: Opting In Again
+spec:
+  Name: Thing 3
+  From: Cat in the Hat
+  By: Dr. Seuss
+  For: Reasons


### PR DESCRIPTION
Signed-off-by: Derek Rushing <derek.rushing21@gmail.com>

# What Are We Doing Here

Adding the ability to 'opt-in' for Lostromos use by CRs. If given opt-in criteria, custom resources should have an annotation with the given opt-in key in order to have the watcher pass on information to the controllers.

## How to Verify

1. Check out this PR and run `make build`.
2. Start minikube and run `kubectl apply -f test/data/crd.yml`.
3. Run `kubectl apply -f test/data/cr_things.yml`
4. Finally run `./lostromos start --config test/data/config.yaml --nop --crd-optIn optIn` and see that the resources aren't printed.
5. Run `kubectl delete -f test/data/cr_things.yml`
6. Add an annotation to Thing1 with key/values of `optIn: "true"`
7. Re-run step 3 and see that Lostromos now prints out Thing1