### PR TITLE
added a generic Dockerfile to root of repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM golang:alpine AS build-env
+
+# Install any compile-time system dependencies.
+RUN apk add --no-cache git curl
+RUN go get -u github.com/golang/dep/...
+ENV KUBECTL_VERSION v1.7.9
+RUN curl -L -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
+RUN chmod +x /usr/bin/kubectl
+
+# Copy lostromos into the build environment.
+WORKDIR /go/src/github.com/wpengine/lostromos
+COPY .  /go/src/github.com/wpengine/lostromos
+
+# Install any compile-time golang dependencies.
+RUN dep ensure
+RUN CGO_ENABLED=0 go install github.com/wpengine/lostromos
+
+FROM alpine:latest
+
+# Add a lostromos user
+RUN adduser -D lostromos
+USER lostromos
+
+# Add our compiled binary and kubectl
+COPY --from=build-env /go/bin/lostromos /lostromos
+COPY --from=build-env /usr/bin/kubectl /usr/bin/kubectl
+
+ENTRYPOINT ["/lostromos"]


### PR DESCRIPTION
# What Are We Doing Here

This change introduces a Dockerfile with Lostromos as the entrypoint. It allows users to run Lostromos in docker similar to how one would run a compiled binary.

```sh
$ docker run lostromos-test:latest --help                                                                                                       dockerfile
Lostromos will monitor all the resources created in your K8s CRD
and create, update, and delete resources based on the templates provided.

Usage:
  lostromos [command]

Available Commands:
  check       Check that results of your template using the given CR.
  help        Help about any command
  start       Start the server.
  version     Show the version number.

Flags:
      --config string   config file (default is /etc/lostromos.yaml)
      --debug           enable debug logging
  -h, --help            help for lostromos
      --pretty          print logs in human readable form instead of json

Use "lostromos [command] --help" for more information about a command.
```

## How to Verify

1. Check out this PR
2. Run `docker build -t lostromos-test:latest .`
3. Run `docker run lostromos-test:latest --help`