### PR TITLE
Upgrade Helm to v2.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: required
 env:
   global:
   - CHANGE_MINIKUBE_NONE_USER=true
-  - KUBERNETES_VERSION=v1.8.0
-  - MINIKUBE_VERSION=v0.24.1
-  - HELM_VERSION=v2.7.2
+  - KUBERNETES_VERSION=v1.9.0
+  - MINIKUBE_VERSION=v0.25.0
+  - HELM_VERSION=v2.8.0
 go:
 - 1.9.x
 - master

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -106,7 +106,7 @@
 [[projects]]
   branch = "master"
   name = "github.com/golang/protobuf"
-  packages = ["proto","ptypes/any","ptypes/timestamp"]
+  packages = ["proto","ptypes","ptypes/any","ptypes/duration","ptypes/timestamp"]
   revision = "1643683e1b54a9e88ad26d98f81400c8c9d9f4f9"
 
 [[projects]]
@@ -338,9 +338,15 @@
   revision = "c01e4764d870b77f8abe5096ee19ad20d80e8075"
 
 [[projects]]
+  branch = "master"
+  name = "google.golang.org/genproto"
+  packages = ["googleapis/rpc/status"]
+  revision = "4eb30f4778eed4c258ba66527a0d4f9ec8a36c45"
+
+[[projects]]
   name = "google.golang.org/grpc"
-  packages = [".","codes","credentials","grpclog","internal","keepalive","metadata","naming","peer","stats","tap","transport"]
-  revision = "8050b9cbc271307e5a716a9d782803d09b0d6f2d"
+  packages = [".","balancer","codes","connectivity","credentials","grpclb/grpc_lb_v1/messages","grpclog","internal","keepalive","metadata","naming","peer","resolver","stats","status","tap","transport"]
+  revision = "5ffe3083946d5603a0578721101dc8165b1d5b5f"
 
 [[projects]]
   name = "gopkg.in/inf.v0"
@@ -355,10 +361,10 @@
   revision = "eb3733d160e74a9c7e442f435eb3bea458e1d19f"
 
 [[projects]]
-  branch = "master"
+  branch = "release-1.9"
   name = "k8s.io/api"
-  packages = ["admissionregistration/v1alpha1","apps/v1beta1","apps/v1beta2","authentication/v1","authentication/v1beta1","authorization/v1","authorization/v1beta1","autoscaling/v1","autoscaling/v2beta1","batch/v1","batch/v1beta1","batch/v2alpha1","certificates/v1beta1","core/v1","extensions/v1beta1","networking/v1","policy/v1beta1","rbac/v1","rbac/v1alpha1","rbac/v1beta1","scheduling/v1alpha1","settings/v1alpha1","storage/v1","storage/v1beta1"]
-  revision = "218912509d74a117d05a718bb926d0948e531c20"
+  packages = ["admissionregistration/v1alpha1","admissionregistration/v1beta1","apps/v1","apps/v1beta1","apps/v1beta2","authentication/v1","authentication/v1beta1","authorization/v1","authorization/v1beta1","autoscaling/v1","autoscaling/v2beta1","batch/v1","batch/v1beta1","batch/v2alpha1","certificates/v1beta1","core/v1","events/v1beta1","extensions/v1beta1","networking/v1","policy/v1beta1","rbac/v1","rbac/v1alpha1","rbac/v1beta1","scheduling/v1alpha1","settings/v1alpha1","storage/v1","storage/v1alpha1","storage/v1beta1"]
+  revision = "acf347b865f29325eb61f4cd2df11e86e073a5ee"
 
 [[projects]]
   name = "k8s.io/apimachinery"
@@ -367,14 +373,15 @@
 
 [[projects]]
   name = "k8s.io/client-go"
-  packages = ["dynamic","kubernetes/scheme","pkg/version","rest","rest/watch","tools/auth","tools/cache","tools/clientcmd","tools/clientcmd/api","tools/clientcmd/api/latest","tools/clientcmd/api/v1","tools/metrics","tools/pager","transport","util/cert","util/flowcontrol","util/homedir","util/integer"]
-  revision = "82aa063804cf055e16e8911250f888bc216e8b61"
+  packages = ["dynamic","kubernetes/scheme","pkg/version","rest","rest/watch","tools/auth","tools/cache","tools/clientcmd","tools/clientcmd/api","tools/clientcmd/api/latest","tools/clientcmd/api/v1","tools/metrics","tools/pager","transport","util/buffer","util/cert","util/flowcontrol","util/homedir","util/integer"]
+  revision = "78700dec6369ba22221b72770783300f143df150"
+  version = "v6.0.0"
 
 [[projects]]
   name = "k8s.io/helm"
-  packages = ["pkg/chartutil","pkg/helm","pkg/ignore","pkg/proto/hapi/chart","pkg/proto/hapi/release","pkg/proto/hapi/services","pkg/proto/hapi/version","pkg/version"]
-  revision = "08c1144f5eb3e3b636d9775617287cc26e53dba4"
-  version = "v2.7.0"
+  packages = ["pkg/chartutil","pkg/helm","pkg/ignore","pkg/proto/hapi/chart","pkg/proto/hapi/release","pkg/proto/hapi/services","pkg/proto/hapi/version","pkg/sympath","pkg/version"]
+  revision = "14af25f1de6832228539259b821949d20069a222"
+  version = "v2.8.0"
 
 [[projects]]
   branch = "master"
@@ -385,6 +392,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "fb0558df8060fd290a7e5ef8c4d8ce229fd29230be237e128f85cc0f53776db7"
+  inputs-digest = "b7ed8e1248a635a59eb62548a9c08d9be9078c6b7c2afc18a12383c8f6070ebd"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -8,13 +8,7 @@
 
 [[constraint]]
   name = "k8s.io/client-go"
-  # version = "^4.0.0"
-  revision = "82aa063804cf055e16e8911250f888bc216e8b61"
-
-# Found in https://github.com/kubernetes/client-go/blob/release-4.0/Godeps/Godeps.json
-[[override]]
-  name = "k8s.io/apimachinery"
-  revision = "3b05bbfa0a45413bfa184edbf9af617e277962fb" #"917740426ad66ff818da4809990480bcc0786a77"
+  version = "6.0.0"
 
 [[constraint]]
   name = "github.com/stretchr/testify"
@@ -30,12 +24,19 @@
 
 [[constraint]]
   name = "k8s.io/helm"
-  version = "2.7.0"
+  version = "2.8.0"
+
+[[constraint]]
+  name = "k8s.io/kubernetes"
+  branch = "release-1.9"
+
+[[override]]
+  name = "k8s.io/api"
+  branch = "release-1.9"
 
 [[override]]
   name = "google.golang.org/grpc"
-  # packages = ["codes", "credentials", "grpclog", "internal", "keepalive", "metadata", "naming", "peer", "stats", "tap", "transport"]
-  revision = "8050b9cbc271307e5a716a9d782803d09b0d6f2d"
+  revision = "5ffe3083946d5603a0578721101dc8165b1d5b5f"
 
 [[constraint]]
   name = "go.uber.org/zap"

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -16,7 +16,7 @@ deployment. If you are in a different namespace you would use
 ## Version
 
 Helm requires the the tiller and the client be running the same version.
-Currently Lostrómos uses version v2.7.0 of Helm.
+Currently Lostrómos uses version v2.8.0 of Helm.
 
 ## Running outside the cluster
 

--- a/helmctlr/mock_helm_test.go
+++ b/helmctlr/mock_helm_test.go
@@ -248,3 +248,15 @@ func (_mr *MockInterfaceMockRecorder) RunReleaseTest(arg0 interface{}, arg1 ...i
 	_s := append([]interface{}{arg0}, arg1...)
 	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "RunReleaseTest", reflect.TypeOf((*MockInterface)(nil).RunReleaseTest), _s...)
 }
+
+// PingTiller mocks base method
+func (_m *MockInterface) PingTiller() error {
+	ret := _m.ctrl.Call(_m, "PingTiller")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PingTiller indicates an expected call of PingTiller
+func (_mr *MockInterfaceMockRecorder) PingTiller() *gomock.Call {
+	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "PingTiller", reflect.TypeOf((*MockInterface)(nil).PingTiller))
+}


### PR DESCRIPTION
# What Are We Doing Here

Upgrading our Helm support to v2.8.0 and K8s to v1.9.0

NO new functionality

## How to Verify

1. Check out this PR
2. Run tests and ensure everything still works