### PR TITLE
Update dockerfile to include build version in binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM golang:alpine AS build-env
 
 # Install any compile-time system dependencies.
-RUN apk add --no-cache git curl
+RUN apk add --no-cache git curl make
 RUN go get -u github.com/golang/dep/...
-ENV KUBECTL_VERSION v1.7.9
+ENV KUBECTL_VERSION v1.9.2
 RUN curl -L -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
 RUN chmod +x /usr/bin/kubectl
 
@@ -13,7 +13,7 @@ COPY .  /go/src/github.com/wpengine/lostromos
 
 # Install any compile-time golang dependencies.
 RUN dep ensure
-RUN CGO_ENABLED=0 go install github.com/wpengine/lostromos
+RUN make out/lostromos-linux-amd64
 
 FROM alpine:latest
 
@@ -22,7 +22,7 @@ RUN adduser -D lostromos
 USER lostromos
 
 # Add our compiled binary and kubectl
-COPY --from=build-env /go/bin/lostromos /lostromos
+COPY --from=build-env /go/src/github.com/wpengine/lostromos/out/lostromos-linux-amd64 /lostromos
 COPY --from=build-env /usr/bin/kubectl /usr/bin/kubectl
 
 ENTRYPOINT ["/lostromos"]


### PR DESCRIPTION
# What Are We Doing Here

Currently our dockerfile builds a docker image that doesn't have any version info. This commit switches the build to use our standard make target which populates this information.

## How to Verify

1. Check out this PR
2. Run `docker build -t lostromos .`
3. Run `docker run --rm -ti lostromos version` and ensure version info is printed out and isn't blank.