### PR TITLE
Changing wpdrush21 to drush211

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,13 +1,4 @@
 # CODEOWNERS: https://help.github.com/articles/about-codeowners/
 
 # These owners will be the default owners for everything in the repo.
-*       @nicolerenee @lvaughn
-
-# The owners are responsible for documentation files
-*.md   @nicolerenee @lvaughn @wpdrush21
-
-# These owners are responsible for the continuous integration file
-.travis.yml @nicolerenee @lvaughn @wpdrush21
-
-# These owners are responsible for the Dockerfile
-Dockerfile @nicolerenee @lvaughn @wpdrush21
+*       @nicolerenee @lvaughn @drush211


### PR DESCRIPTION
Signed-off-by: drush211 <thedrush21@gmail.com>

# What Are We Doing Here

Changing wpdrush21 to drush211 to be able to continue Lostromos review/work.

## How to Verify

1. Check out this PR
2. Run Command X, Click Button Y
3. Profit