### PR TITLE
Added metrics to add timestamp create/update/delete events

### DIFF
--- a/helmctlr/helm.go
+++ b/helmctlr/helm.go
@@ -16,6 +16,7 @@ package helmctlr
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/ghodss/yaml"
 	"github.com/wpengine/lostromos/metrics"
@@ -72,6 +73,7 @@ func (c Controller) ResourceAdded(r *unstructured.Unstructured) {
 	}
 	metrics.CreatedReleases.Inc()
 	metrics.ManagedReleases.Inc()
+	metrics.LastSuccessfulCreate.Set(float64(time.Now().UTC().UnixNano()) / 1000000000)
 }
 
 // ResourceDeleted is called when a custom resource is created and will use
@@ -88,6 +90,7 @@ func (c Controller) ResourceDeleted(r *unstructured.Unstructured) {
 	}
 	metrics.DeletedReleases.Inc()
 	metrics.ManagedReleases.Dec()
+	metrics.LastSuccessfulDelete.Set(float64(time.Now().UTC().UnixNano()) / 1000000000)
 }
 
 // ResourceUpdated is called when a custom resource is updated or during a
@@ -101,6 +104,7 @@ func (c Controller) ResourceUpdated(oldR, newR *unstructured.Unstructured) {
 		return
 	}
 	metrics.UpdatedReleases.Inc()
+	metrics.LastSuccessfulUpdate.Set(float64(time.Now().UTC().UnixNano()) / 1000000000)
 }
 
 func (c Controller) delete(r *unstructured.Unstructured) error {

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -34,6 +34,13 @@ var (
 		Namespace: "releases",
 	})
 
+	// LastSuccessfulCreate is a timestamp in UTC seconds of the last successful create event
+	LastSuccessfulCreate = prometheus.NewGauge(prometheus.GaugeOpts{
+		Help:      "A Unix timestamp (UTC) in seconds of the last successful create event",
+		Name:      "last_create_timestamp_utc_seconds",
+		Namespace: "releases",
+	})
+
 	// DeleteFailures is a metric for the number of times a delete by this operator
 	DeleteFailures = prometheus.NewCounter(prometheus.CounterOpts{
 		Help:      "The number of failed delete events",
@@ -45,6 +52,13 @@ var (
 	DeletedReleases = prometheus.NewCounter(prometheus.CounterOpts{
 		Help:      "The number of successful delete events",
 		Name:      "delete_total",
+		Namespace: "releases",
+	})
+
+	// LastSuccessfulDelete is a timestamp in UTC seconds of the last successful delete event
+	LastSuccessfulDelete = prometheus.NewGauge(prometheus.GaugeOpts{
+		Help:      "A Unix timestamp (UTC) in seconds of the last successful delete event",
+		Name:      "last_delete_timestamp_utc_seconds",
 		Namespace: "releases",
 	})
 
@@ -69,6 +83,13 @@ var (
 		Namespace: "releases",
 	})
 
+	// LastSuccessfulUpdate is a timestamp in UTC seconds of the last successful update event
+	LastSuccessfulUpdate = prometheus.NewGauge(prometheus.GaugeOpts{
+		Help:      "A Unix timestamp (UTC) in seconds of the last successful update event",
+		Name:      "last_update_timestamp_utc_seconds",
+		Namespace: "releases",
+	})
+
 	// TotalEvents is a metric for the number of events that have been handled by this operator
 	TotalEvents = prometheus.NewCounter(prometheus.CounterOpts{
 		Help:      "The number of events (create/delete/updates) processed by this operator",
@@ -80,10 +101,13 @@ var (
 func init() {
 	prometheus.MustRegister(CreatedReleases)
 	prometheus.MustRegister(CreateFailures)
+	prometheus.MustRegister(LastSuccessfulCreate)
 	prometheus.MustRegister(DeletedReleases)
 	prometheus.MustRegister(DeleteFailures)
+	prometheus.MustRegister(LastSuccessfulDelete)
 	prometheus.MustRegister(ManagedReleases)
 	prometheus.MustRegister(UpdatedReleases)
 	prometheus.MustRegister(UpdateFailures)
+	prometheus.MustRegister(LastSuccessfulUpdate)
 	prometheus.MustRegister(TotalEvents)
 }

--- a/printctlr/controller.go
+++ b/printctlr/controller.go
@@ -16,6 +16,7 @@ package printctlr
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/wpengine/lostromos/metrics"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -34,6 +35,7 @@ func (c Controller) ResourceAdded(r *unstructured.Unstructured) {
 	metrics.CreatedReleases.Inc()
 	metrics.ManagedReleases.Inc()
 	metrics.TotalEvents.Inc()
+	metrics.LastSuccessfulCreate.Set(float64(time.Now().UTC().UnixNano()) / 1000000000)
 }
 
 // ResourceUpdated receives both an the old version and current version of a
@@ -42,6 +44,7 @@ func (c Controller) ResourceUpdated(oldR, newR *unstructured.Unstructured) {
 	fmt.Printf("CR changed: %s\n", newR.GetName())
 	metrics.UpdatedReleases.Inc()
 	metrics.TotalEvents.Inc()
+	metrics.LastSuccessfulUpdate.Set(float64(time.Now().UTC().UnixNano()) / 1000000000)
 }
 
 // ResourceDeleted will receive a custom resource when it is deleted and
@@ -51,4 +54,5 @@ func (c Controller) ResourceDeleted(r *unstructured.Unstructured) {
 	metrics.DeletedReleases.Inc()
 	metrics.ManagedReleases.Dec()
 	metrics.TotalEvents.Inc()
+	metrics.LastSuccessfulDelete.Set(float64(time.Now().UTC().UnixNano()) / 1000000000)
 }

--- a/tmplctlr/controller.go
+++ b/tmplctlr/controller.go
@@ -18,6 +18,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/wpengine/lostromos/metrics"
 	"github.com/wpengine/lostromos/tmpl"
@@ -60,6 +61,7 @@ func (c Controller) ResourceAdded(r *unstructured.Unstructured) {
 	}
 	metrics.CreatedReleases.Inc()
 	metrics.ManagedReleases.Inc()
+	metrics.LastSuccessfulCreate.Set(float64(time.Now().UTC().UnixNano()) / 1000000000)
 }
 
 // ResourceUpdated is called when a custom resource is updated or during a
@@ -74,6 +76,7 @@ func (c Controller) ResourceUpdated(oldR, newR *unstructured.Unstructured) {
 		return
 	}
 	metrics.UpdatedReleases.Inc()
+	metrics.LastSuccessfulUpdate.Set(float64(time.Now().UTC().UnixNano()) / 1000000000)
 }
 
 // ResourceDeleted is called when a custom resource is created and will generate
@@ -89,6 +92,7 @@ func (c Controller) ResourceDeleted(r *unstructured.Unstructured) {
 	}
 	metrics.DeletedReleases.Inc()
 	metrics.ManagedReleases.Dec()
+	metrics.LastSuccessfulDelete.Set(float64(time.Now().UTC().UnixNano()) / 1000000000)
 }
 
 func (c Controller) apply(r *unstructured.Unstructured) (output string, err error) {


### PR DESCRIPTION
Added metrics to set a timestamp for last successful create/update/delete event

Signed-off-by: Natalie Rogers <natalie.rogers@wpengine.com>

# What Are We Doing Here

Here is where you should describe the problem you are solving, adding any fine details on the solution that might
otherwise not be recognizable for someone unfamiliar with the changes. Add some pictures if it helps.

## How to Verify

1. Check out this PR
2. Run Command X, Click Button Y
3. Profit