### PR TITLE
remove extension in SetConfigName()

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -74,7 +74,7 @@ func initConfig() {
 	} else {
 		// Use default config file /etc/lostromos.yaml
 		viper.AddConfigPath("/etc")
-		viper.SetConfigName("lostromos.yaml")
+		viper.SetConfigName("lostromos")
 	}
 
 	viper.AutomaticEnv() // read in environment variables that match


### PR DESCRIPTION
As mentioned in https://github.com/spf13/viper/blob/b5e8006cbee93ec955a89ab31e0e3ce3204f3736/viper.go#L1685 SetConfigName() may not include an extension.

```
# sudo dtruss -f -t stat64 lostromos start
...
22972/0x775103:  stat64("/etc/lostromos.yaml.json\0", 0xC420236928, 0x0)         = -1 Err#2
22972/0x775103:  stat64("/etc/lostromos.yaml.toml\0", 0xC4202369F8, 0x0)         = -1 Err#2
22972/0x775103:  stat64("/etc/lostromos.yaml.yaml\0", 0xC420236AC8, 0x0)         = -1 Err#2
22972/0x775103:  stat64("/etc/lostromos.yaml.yml\0", 0xC420236B98, 0x0)         = -1 Err#2
22972/0x775103:  stat64("/etc/lostromos.yaml.properties\0", 0xC420236C68, 0x0)         = -1 Err#2
22972/0x775103:  stat64("/etc/lostromos.yaml.props\0", 0xC420236D38, 0x0)         = -1 Err#2
22972/0x775103:  stat64("/etc/lostromos.yaml.prop\0", 0xC420236E08, 0x0)         = -1 Err#2
22972/0x775103:  stat64("/etc/lostromos.yaml.hcl\0", 0xC420236ED8, 0x0)         = -1 Err#2

# sed -i.orig -e 's|lostromos\.yaml|lostromos|' cmd/cmd.go
# go get github.com/wpengine/lostromos
# sudo dtruss -f -t stat64 lostromos start
...
23191/0x776348:  stat64("/etc/lostromos.json\0", 0xC42025C9F8, 0x0)         = -1 Err#2
23191/0x776348:  stat64("/etc/lostromos.toml\0", 0xC42025CAC8, 0x0)         = -1 Err#2
23191/0x776348:  stat64("/etc/lostromos.yaml\0", 0xC42025CB98, 0x0)         = -1 Err#2
23191/0x776348:  stat64("/etc/lostromos.yml\0", 0xC42025CC68, 0x0)         = -1 Err#2
23191/0x776348:  stat64("/etc/lostromos.properties\0", 0xC42025CD38, 0x0)         = -1 Err#2
23191/0x776348:  stat64("/etc/lostromos.props\0", 0xC42025CE08, 0x0)         = -1 Err#2
23191/0x776348:  stat64("/etc/lostromos.prop\0", 0xC42025CED8, 0x0)         = -1 Err#2
23191/0x776348:  stat64("/etc/lostromos.hcl\0", 0xC42025CFA8, 0x0)         = -1 Err#2
```

# What Are We Doing Here

Just fix SetConfigName(), so the config file in its default location is recognized.

## How to Verify

1. Check out this PR
2. Build the binary.
3. Save https://github.com/wpengine/lostromos/raw/master/test/data/config.yaml under `/etc/lostromos.yaml`.
3. Trace like `strace -f -e stat lostromos start 2>&1 | grep -i '/etc/lostromos'`.