### PR TITLE
Update wpengine references

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -44,7 +44,7 @@ event. Representation of a project may be further defined and clarified by proje
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at
-nicole@wpengine.com. The project team will review and investigate all complaints, and will respond in a way that it
+nicole@nicolerenee.io. The project team will review and investigate all complaints, and will respond in a way that it
 deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the
 reporter of an incident. Further details of specific enforcement policies may be posted separately.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,11 +4,11 @@
 
 ## <a name="bugs"></a>Report a Bug
 
-To report an issue or suggest an improvement please open an [issue](https://github.com/wpengine/lostromos/issues).
+To report an issue or suggest an improvement please open an [issue](https://github.com/lostromos/lostromos/issues).
 
 If you are reporting a security issue, do not create an issue or file a pull
 request on GitHub. Instead, disclose the issue responsibly by sending an email
-to security@wpengine.com.
+to the maintainer.
 
 ## Pull requests are always welcome
 

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,1 +1,1 @@
-Nicole Renée Hubbard <nicole@wpengine.com> (@nicolerenee)
+Nicole Renée Hubbard <nicole@nicolerenee.io> (@nicolerenee)

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ LD_FLAGS      := -s -w -X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Gi
 MARKDOWN_LINTER := wpengine/mdl
 PYTHON_LINTER := wpengine/pylint
 
-OWNER=wpengine
+OWNER=lostromos
 IMAGE_NAME=lostromos
 QNAME=$(OWNER)/$(IMAGE_NAME)
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -51,7 +51,7 @@ func init() {
 	LostromosCmd.AddCommand(startCmd)
 
 	startCmd.Flags().String("crd-name", "", "the plural name of the CRD you want monitored (ex: users)")
-	startCmd.Flags().String("crd-group", "", "the group of the CRD you want monitored (ex: stable.wpengine.io)")
+	startCmd.Flags().String("crd-group", "", "the group of the CRD you want monitored (ex: stable.nicolerenee.io)")
 	startCmd.Flags().String("crd-version", "v1", "the version of the CRD you want monitored")
 	startCmd.Flags().String("crd-namespace", metav1.NamespaceNone, "(optional) the namespace of the CRD you want monitored, only needed for namespaced CRDs (ex: default)")
 	startCmd.Flags().String("crd-filter", "", "(optional) Annotation key to specify that the custom resource has opted in to watching by Lostromos")

--- a/crwatcher/watcher_test.go
+++ b/crwatcher/watcher_test.go
@@ -110,7 +110,7 @@ func TestSetupHandlerAddFuncUsesFilter(t *testing.T) {
 	mockRC := NewMockResourceController(mockCtrl)
 	cw := &CRWatcher{
 		Config: &Config{
-			Filter: "com.wpengine.lostromos.filter",
+			Filter: "io.nicolerenee.lostromos.filter",
 		},
 	}
 	r1 := &unstructured.Unstructured{
@@ -125,7 +125,7 @@ func TestSetupHandlerAddFuncUsesFilter(t *testing.T) {
 			"metadata": map[string]interface{}{
 				"name": "Thing2",
 				"annotations": map[string]interface{}{
-					"com.wpengine.lostromos.filter": "true",
+					"io.nicolerenee.lostromos.filter": "true",
 				},
 			},
 		},
@@ -170,7 +170,7 @@ func TestSetupHandlerDeleteFuncUsesFilter(t *testing.T) {
 	mockRC := NewMockResourceController(mockCtrl)
 	cw := &CRWatcher{
 		Config: &Config{
-			Filter: "com.wpengine.lostromos.filter",
+			Filter: "io.nicolerenee.lostromos.filter",
 		},
 	}
 	r1 := &unstructured.Unstructured{
@@ -185,7 +185,7 @@ func TestSetupHandlerDeleteFuncUsesFilter(t *testing.T) {
 			"metadata": map[string]interface{}{
 				"name": "Thing2",
 				"annotations": map[string]interface{}{
-					"com.wpengine.lostromos.filter": "true",
+					"io.nicolerenee.lostromos.filter": "true",
 				},
 			},
 		},
@@ -237,7 +237,7 @@ func TestSetupHandlerUpdateFuncUsesFilter(t *testing.T) {
 	mockRC := NewMockResourceController(mockCtrl)
 	cw := &CRWatcher{
 		Config: &Config{
-			Filter: "com.wpengine.lostromos.filter",
+			Filter: "io.nicolerenee.lostromos.filter",
 		},
 	}
 	r1 := &unstructured.Unstructured{
@@ -252,7 +252,7 @@ func TestSetupHandlerUpdateFuncUsesFilter(t *testing.T) {
 			"metadata": map[string]interface{}{
 				"name": "Thing1",
 				"annotations": map[string]interface{}{
-					"com.wpengine.lostromos.filter": "true",
+					"io.nicolerenee.lostromos.filter": "true",
 				},
 			},
 		},
@@ -269,7 +269,7 @@ func TestSetupHandlerUpdateFuncUsesFilter(t *testing.T) {
 			"metadata": map[string]interface{}{
 				"name": "Thing2",
 				"annotations": map[string]interface{}{
-					"com.wpengine.lostromos.filter": "true",
+					"io.nicolerenee.lostromos.filter": "true",
 				},
 			},
 		},

--- a/docs/usinglostromos.md
+++ b/docs/usinglostromos.md
@@ -94,7 +94,7 @@ will watch for add/update/delete
   * `name` (Required) The plural name of the Custom Resource Definition (CRD)
   you want monitored (ex: users)
   * `group` (Required) The group of the CRD you want monitored
-  (ex: stable.wpengine.io)
+  (ex: stable.nicolerenee.io)
   * `version` (Required) The version of the CRD you want monitored
   * `namespace` The namespace of the CRD you want monitored
   * `filter` Filter to specify if Lostromos will act on a resource


### PR DESCRIPTION
Signed-off-by: Alan Arvesen <alan.arvesen@wpengine.com>

# What Are We Doing Here

Removing WPEngine verbiage from the repo.  An additional PR will be needed to update packages, etc.