### PR TITLE
Update go linting to use the new golangci-lint Closes: #82

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - MINIKUBE_VERSION=v0.25.0
   - HELM_VERSION=v2.8.0
 go:
-- 1.9.x
+- 1.12.x
 - master
 services:
 - docker
@@ -55,4 +55,4 @@ deploy:
   on:
     repo: lostromos/lostromos
     tags: true
-    condition: $TRAVIS_GO_VERSION =~ ^1\.9\.[0-9]+$
+    condition: $TRAVIS_GO_VERSION =~ ^1\.12\.[0-9]+$

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ lint: golint lint-python lint-markdown
 
 golint: | vendor
 	@echo Linting Go files...
-	@CGO_ENABLED=0 gometalinter --vendor --deadline=240s --enable=gofmt --disable=gotype ./...
+	@CGO_ENABLED=0 golangci-lint run --deadline=5m --enable goimports ./...
 
 lint-markdown:
 	@echo Linting Markdown files...
@@ -69,8 +69,7 @@ lint-python:
 
 install-go-deps:
 	go get -u github.com/golang/dep/cmd/dep
-	go get -u github.com/alecthomas/gometalinter
-	gometalinter --install
+	go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 
 install-python-deps:
 	pip3 install -r requirements.txt


### PR DESCRIPTION
# What Are We Doing Here

Replacing gometalinter with golangci-lint

## How to Verify

1. Check out this PR
2. Run `make golint`
3. Everything should still pass linting